### PR TITLE
Flood queue implementation

### DIFF
--- a/.idea/modules/Common.iml
+++ b/.idea/modules/Common.iml
@@ -13,19 +13,19 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
     <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
   </component>
 </module>

--- a/.idea/modules/ecsAlertLambda.iml
+++ b/.idea/modules/ecsAlertLambda.iml
@@ -13,54 +13,54 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.346:jar" level="project" />
-    <orderEntry type="module" module-name="Common" exported="" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-api:2.8.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-log4j2:1.0.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-core:1.1.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-events:2.1.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sqs:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-lambda:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-ecs:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-core:2.8.2:jar" level="project" />
     <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-core:2.8.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-ecs:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-lambda:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sqs:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-events:2.1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-core:1.1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-log4j2:1.0.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-api:2.8.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
+    <orderEntry type="module" module-name="Common" exported="" />
   </component>
 </module>

--- a/.idea/modules/transcoderReplyLambda.iml
+++ b/.idea/modules/transcoderReplyLambda.iml
@@ -14,55 +14,55 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.346:jar" level="project" />
-    <orderEntry type="module" module-name="Common" exported="" />
-    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-core:2.8.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-api:2.8.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-log4j2:1.0.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-events:2.1.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-core:1.1.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-lambda:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-elastictranscoder:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sns:1.11.346:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sqs:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sns:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-elastictranscoder:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-lambda:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-core:1.1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-events:2.1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-log4j2:1.0.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-core:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-databind:2.6.7.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-codec:commons-codec:1.10:jar" level="project" />
+    <orderEntry type="library" name="sbt: commons-logging:commons-logging:1.1.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-api:2.8.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-core:2.8.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-matcher_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-mock_2.12:4.3.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
+    <orderEntry type="module" module-name="Common" exported="" />
   </component>
 </module>

--- a/ProxyRequestLambda/src/main/scala/ContainerTaskManager.scala
+++ b/ProxyRequestLambda/src/main/scala/ContainerTaskManager.scala
@@ -9,10 +9,12 @@ class ContainerTaskManager (clusterName:String,taskDefinitionName:String,taskCon
   private val logger = LogManager.getLogger(getClass)
 
   def getPendingTaskCount(implicit client:AmazonECS) = Try {
-    val rq = new DescribeTasksRequest().withCluster(clusterName)
-    val result = client.describeTasks(rq)
-
-    result.getTasks.asScala.filter(_.getDesiredStatus!="STOPPED").length
+//    val rq = new DescribeTasksRequest().withCluster(clusterName)
+//    val result = client.describeTasks(rq)
+//
+//    result.getTasks.asScala.filter(_.getDesiredStatus!="STOPPED").length
+    val result = client.describeClusters(new DescribeClustersRequest().withClusters(clusterName))
+    result.getClusters.asScala.head.getRunningTasksCount //we only asked for one cluster, so we should only get one.
   }
 
   def runTask(command:Seq[String], environment:Map[String,String], name:String, cpu:Option[Int]=None)(implicit client:AmazonECS) = {

--- a/ProxyRequestLambda/src/main/scala/ETSPipelineManager.scala
+++ b/ProxyRequestLambda/src/main/scala/ETSPipelineManager.scala
@@ -110,21 +110,16 @@ class ETSPipelineManager {
       result.getPipeline
     }
 
-  def makeJobRequest(inputPath:String,outputPath:String, presetId:String, pipelineId:String, jobId:String, proxyType: ProxyType.Value)(implicit etsClient:AmazonElasticTranscoder) = {
+  def makeJobRequest(inputPath:String,outputPath:String, presetId:String, pipelineId:String, jobId:String, proxyType: ProxyType.Value)(implicit etsClient:AmazonElasticTranscoder) = Try {
     val rq = new CreateJobRequest()
       .withInput(new JobInput().withKey(inputPath))
       .withOutput(new CreateJobOutput().withKey(outputPath).withPresetId(presetId))
       .withPipelineId(pipelineId)
       //base64 encoded version of this can be no more than 256 bytes!
       .withUserMetadata(Map("archivehunter-job-id" -> jobId, "proxy-type" -> proxyType.toString).asJava)
-    try {
+
       val result = etsClient.createJob(rq)
       println(s"Started transcode job with ID ${result.getJob.getId}")
-      Right(result.getJob.getId)
-    } catch {
-      case err:Throwable=>
-        println(s"ERROR: Could not start transcode job: $err")
-        Left(err.toString)
-    }
+      result.getJob.getId
   }
 }

--- a/ProxyRequestLambda/src/main/scala/ETSPipelineManager.scala
+++ b/ProxyRequestLambda/src/main/scala/ETSPipelineManager.scala
@@ -110,7 +110,18 @@ class ETSPipelineManager {
       result.getPipeline
     }
 
-  def makeJobRequest(inputPath:String,outputPath:String, presetId:String, pipelineId:String, jobId:String, proxyType: ProxyType.Value)(implicit etsClient:AmazonElasticTranscoder) = Try {
+  /**
+    * create a job on Elastic Transcoder
+    * @param inputPath path to input media in the S3 bucket for the pipeline referred to by `pipelineId`
+    * @param outputPath path to output media in the S3 bucket for the output pipeline referred to by `pipelineId`
+    * @param presetId ID of the preset to use for transcoding
+    * @param pipelineId ID of the pipeline to use for transcoding
+    * @param jobId ArchiveHunter job ID. this is carried with the job so that the app knows which entry the transcode is for
+    * @param proxyType ProxyType value indicating, well, the type of proxy to generate
+    * @param etsClient implicitly provided elastic transcoder client
+    * @return Success with the ETS Job ID, or a Failure indicating the error.
+    */
+  def makeJobRequest(inputPath:String,outputPath:String, presetId:String, pipelineId:String, jobId:String, proxyType: ProxyType.Value)(implicit etsClient:AmazonElasticTranscoder):Try[String] = Try {
     val rq = new CreateJobRequest()
       .withInput(new JobInput().withKey(inputPath))
       .withOutput(new CreateJobOutput().withKey(outputPath).withPresetId(presetId))

--- a/ProxyRequestLambda/src/main/scala/RequestLambdaMain.scala
+++ b/ProxyRequestLambda/src/main/scala/RequestLambdaMain.scala
@@ -1,5 +1,4 @@
 import java.net.URLDecoder
-
 import com.amazonaws.services.ecs.{AmazonECS, AmazonECSClientBuilder}
 import com.amazonaws.services.elastictranscoder.{AmazonElasticTranscoder, AmazonElasticTranscoderClientBuilder}
 import com.amazonaws.services.elastictranscoder.model._
@@ -7,18 +6,20 @@ import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.amazonaws.services.lambda.runtime.events.SNSEvent
 import com.amazonaws.services.sns.AmazonSNSClientBuilder
 import com.amazonaws.services.sns.model.PublishRequest
-
+import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
+import com.amazonaws.services.sqs.model.SendMessageRequest
 import scala.collection.JavaConverters._
 import io.circe.syntax._
 import io.circe.generic.auto._
-
+import scala.annotation.switch
 import scala.concurrent.{Await, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 import scala.concurrent.duration._
 
 class RequestLambdaMain extends RequestHandler[SNSEvent,Unit] with RequestModelEncoder with JobReportStatusEncoder {
   def getSnsClient = AmazonSNSClientBuilder.defaultClient()
+  def getSqsClient = AmazonSQSClientBuilder.defaultClient()
   def getEcsClient = AmazonECSClientBuilder.defaultClient()
   def getEtsClient = AmazonElasticTranscoderClientBuilder.defaultClient()
 
@@ -68,6 +69,63 @@ class RequestLambdaMain extends RequestHandler[SNSEvent,Unit] with RequestModelE
         Left("Could not create pipeline")
     }
   }
+
+  /**
+    * re-serialize the request and push it onto the flood queue.
+    * @param sqsClient AmazonSQS instance
+    * @param rq requestModel to send
+    * @param floodQueue URL of the flood queue
+    * @return a Try, with either the SendMessageResult or an error
+    */
+  protected def sendToFloodQueue(sqsClient:AmazonSQS, rq:RequestModel, floodQueue:String) = Try {
+    val sendRq = new SendMessageRequest()
+      .withQueueUrl(floodQueue)
+      .withMessageBody(rq.asJson.toString)
+      .withDelaySeconds(randomDelay) //use a randomised delay so the messages don't all come back through at the same time
+
+    sqsClient.sendMessage(sendRq)
+  }
+
+  /**
+    * check whether there are more tasks in an active state than we should have.
+    * if the request fails, then false is returned; the assumption is that any failure in this would also
+    * cause further requests to fail.
+    * @param taskMgr ContainerTaskManager instance
+    * @param settings Settings object
+    * @return boolean, True if we should run the task immediately and False if we should push to flood queue
+    */
+  protected def checkTaskCount(taskMgr:ContainerTaskManager, settings:Settings) = taskMgr.getPendingTaskCount match {
+    case Success(count)=>
+      println(s"Got $count running tasks")
+      if(count>settings.maxRunningTasks){
+        println(s"Limiting to ${settings.maxRunningTasks}, sending to flood queue")
+        false
+      } else {
+        true
+      }
+    case Failure(err)=>
+      println(s"ERROR: Could not check pending task count; $err")
+      false
+  }
+
+  /**
+    * checks whether we should process a request or send it to the flood queue
+    * @param model RequestModel indicating the job to process
+    * @param settings lambda settings
+    * @param taskMgr ContainerTaskManagerInstance
+    * @return a boolean. True if we should process immediately, false if we should send to flood queue
+    */
+  def checkEcsCapacity(model:RequestModel, settings:Settings, taskMgr:ContainerTaskManager) = {
+    model.requestType match {
+      case RequestType.ANALYSE=>
+        checkTaskCount(taskMgr,settings)
+      case RequestType.THUMBNAIL=>
+        checkTaskCount(taskMgr,settings)
+      case _=>  //nothing else requires ECS
+        true
+    }
+  }
+
   /**
     * perform the request that we have been asked to
     * @param model RequestModel desribing the request to perform
@@ -144,6 +202,7 @@ class RequestLambdaMain extends RequestHandler[SNSEvent,Unit] with RequestModelE
             println(s"Could not launch task: $err")
             Left(err.toString)
         }
+
       case RequestType.PROXY=>
         implicit val etsClient = getEtsClient
         val input = PathFunctions.breakdownS3Uri(model.inputMediaUri)
@@ -268,16 +327,31 @@ class RequestLambdaMain extends RequestHandler[SNSEvent,Unit] with RequestModelE
       sys.env.get("AUDIO_PRESET_ID") match {
         case Some(str)=>str
         case None=>throw new RuntimeException("You need to specify AUDIO_PRESET_ID")
-      }
-
+      },
+      sys.env.get("FLOOD_QUEUE") match {
+        case Some(str)=>str
+        case None=>throw new RuntimeException("You need to specify FLOOD_QUEUE")
+      },
+      sys.env.get("MAX_RUNNING_TASKS").map(_.toInt).getOrElse(50)
     )
+  }
+
+  /**
+    * return a randomised number suitable for message delay
+    * @return
+    */
+  def randomDelay:Int = {
+    val upperLimit = 600
+    val lowerLimit = 60
+    val rnd = new scala.util.Random
+    lowerLimit + rnd.nextInt((upperLimit - lowerLimit)+1)
   }
 
   override def handleRequest(evt: SNSEvent, context: Context): Unit = {
     val maybeReqeustsList = evt.getRecords.asScala.map(rec=>{
       io.circe.parser.parse(rec.getSNS.getMessage).flatMap(_.as[RequestModel])
     })
-
+    val sqsClient = getSqsClient
     val failures = maybeReqeustsList.collect({case Left(err)=>err})
 
     if(failures.nonEmpty){
@@ -289,8 +363,31 @@ class RequestLambdaMain extends RequestHandler[SNSEvent,Unit] with RequestModelE
     val settings = getSettings
 
     val taskMgr = new ContainerTaskManager(settings.clusterName,settings.taskDefinitionName,settings.taskContainerName, settings.subnets)
-    val requests = maybeReqeustsList.collect({case Right(rq)=>rq})
-    val toWaitFor = Future.sequence(requests.map(rq=>processRequest(rq, settings, taskMgr)))
+    val initialRequestList = maybeReqeustsList.collect({case Right(rq)=>rq})
+
+    val requestsForNow = initialRequestList.filter(rq=>{
+      (checkEcsCapacity(rq, settings,taskMgr): @switch) match {
+        case true=>true
+        case false=>
+          sendToFloodQueue(sqsClient,rq,settings.floodQueue)
+          false
+      }
+    })
+
+    val toWaitFor = Future.sequence(
+      requestsForNow.map(rq=>
+        processRequest(rq, settings, taskMgr).recover({
+          case err:Throwable=>
+            if(err.getMessage.contains("Rate limit exceeded") ||
+              err.getMessage.contains("Throttling exception") ||
+              err.getMessage.contains("no tasks started")
+            ){
+              println("WARNING: requests are being throttled. Sending this message onto the flood queue.")
+              sendToFloodQueue(sqsClient,rq,settings.floodQueue)
+            }
+        })
+      )
+    )
 
     val results = Await.result(toWaitFor, 60.seconds)
 

--- a/ProxyRequestLambda/src/main/scala/Settings.scala
+++ b/ProxyRequestLambda/src/main/scala/Settings.scala
@@ -1,3 +1,3 @@
 case class Settings(clusterName:String, taskDefinitionName:String, taskContainerName:String,
                     subnets:Option[Seq[String]], replyTopic:String, etsRoleArn:String, etsMessageTopic:String,
-                    videoPresetId:String, audioPresetId:String)
+                    videoPresetId:String, audioPresetId:String, floodQueue:String, maxRunningTasks:Int)

--- a/ProxyRequestLambda/src/test/scala/ETSPipelineManagerSpec.scala
+++ b/ProxyRequestLambda/src/test/scala/ETSPipelineManagerSpec.scala
@@ -19,7 +19,7 @@ class ETSPipelineManagerSpec extends Specification with Mockito {
           .withPipelineId("pipeline-id")
           .withUserMetadata(Map("archivehunter-job-id"->"job-uuid","proxy-type"->"UNKNOWN").asJava)
       there was one(mockedEtsClient).createJob(expectedJobRequest)
-      result must beRight("ets-job-id")
+      result must beSuccessfulTry("ets-job-id")
     }
 
     "error with a Left if the create job request fails" in {
@@ -35,7 +35,7 @@ class ETSPipelineManagerSpec extends Specification with Mockito {
         .withPipelineId("pipeline-id")
         .withUserMetadata(Map("archivehunter-job-id"->"job-uuid","proxy-type"->"UNKNOWN").asJava)
       there was one(mockedEtsClient).createJob(expectedJobRequest)
-      result must beLeft("java.lang.RuntimeException: my hovercraft is full of eels")
+      result must beFailedTry
     }
   }
 }

--- a/ProxyRequestLambda/src/test/scala/RequestLambdaMainSpec.scala
+++ b/ProxyRequestLambda/src/test/scala/RequestLambdaMainSpec.scala
@@ -7,13 +7,15 @@ import com.amazonaws.services.lambda.runtime.events.SNSEvent
 import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNSRecord
 import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.{PublishRequest, PublishResult}
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.SendMessageResult
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import io.circe.syntax._
 import io.circe.generic.auto._
 
 import scala.concurrent.{Await, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
@@ -30,6 +32,10 @@ class RequestLambdaMainSpec extends Specification with Mockito with RequestModel
 
       val toTest = new RequestLambdaMain {
         override def getEcsClient: AmazonECS = mockedEcsClient
+
+        override def getSnsClient: AmazonSNS = mock[AmazonSNS]
+
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
       }
       val result = Await.result(toTest.processRequest(fakeRequest,mockedSettings,mockedTaskMgr), 5 seconds)
 
@@ -47,6 +53,10 @@ class RequestLambdaMainSpec extends Specification with Mockito with RequestModel
 
       val toTest = new RequestLambdaMain {
         override def getEcsClient: AmazonECS = mockedEcsClient
+
+        override def getSnsClient: AmazonSNS = mock[AmazonSNS]
+
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
       }
       val result = Await.result(toTest.processRequest(fakeRequest,mockedSettings,mockedTaskMgr), 5 seconds)
 
@@ -64,6 +74,10 @@ class RequestLambdaMainSpec extends Specification with Mockito with RequestModel
 
       val toTest = new RequestLambdaMain {
         override def getEcsClient: AmazonECS = mockedEcsClient
+
+        override def getSnsClient: AmazonSNS = mock[AmazonSNS]
+
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
       }
       val result = Await.result(toTest.processRequest(fakeRequest,mockedSettings,mockedTaskMgr), 5 seconds)
 
@@ -81,6 +95,11 @@ class RequestLambdaMainSpec extends Specification with Mockito with RequestModel
 
       val toTest = new RequestLambdaMain {
         override def getEcsClient: AmazonECS = mockedEcsClient
+
+        override def getSnsClient: AmazonSNS = mock[AmazonSNS]
+
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
+
       }
       val result = Await.result(toTest.processRequest(fakeRequest,mockedSettings,mockedTaskMgr), 5 seconds)
 
@@ -107,6 +126,10 @@ class RequestLambdaMainSpec extends Specification with Mockito with RequestModel
         override def getEcsClient: AmazonECS = mockedEcsClient
 
         override def getEtsClient: AmazonElasticTranscoder = mockedEtsClient
+
+        override def getSnsClient: AmazonSNS = mock[AmazonSNS]
+
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
 
         override val etsPipelineManager: ETSPipelineManager = mockedPipelineManager
       }
@@ -141,6 +164,7 @@ class RequestLambdaMainSpec extends Specification with Mockito with RequestModel
 
         override def getEtsClient: AmazonElasticTranscoder = mockedEtsClient
 
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
         override def getSnsClient: AmazonSNS = mockedSnsClient
         override val etsPipelineManager: ETSPipelineManager = mockedPipelineManager
       }
@@ -169,13 +193,57 @@ class RequestLambdaMainSpec extends Specification with Mockito with RequestModel
 
       val toTest = new RequestLambdaMain {
         override def getEcsClient: AmazonECS = mock[AmazonECS]
-        override def getSettings: Settings = Settings("fake-cluster-name","fake-task-def","fake-container-name",None,"fake-reply-topic","fake-role-arn","fake-topic","vpreset","apreset")
+
+        override def getSnsClient: AmazonSNS = mock[AmazonSNS]
+
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
+
+        override def getSettings: Settings = Settings("fake-cluster-name","fake-task-def","fake-container-name",None,"fake-reply-topic","fake-role-arn","fake-topic","vpreset","apreset","floodQueue",50)
 
         override def processRequest(model: RequestModel, settings:Settings, taskMgr: ContainerTaskManager): Future[Either[String, String]] = mockProcessRecord(model, settings, taskMgr)
+
+        override def checkEcsCapacity(model: RequestModel, settings: Settings, taskMgr: ContainerTaskManager): Boolean = true
       }
 
       val result = toTest.handleRequest(evt, mock[Context])
       there was one(mockProcessRecord).apply(any,any,any)
+    }
+
+    "send excess requests to the flood queue" in {
+      val actualRequest = RequestModel(RequestType.ANALYSE,"input-uri","target-location","job-id",None,None,None)
+      val recods = List(
+        new SNSRecord().withSns(new SNSEvent.SNS().withMessage(actualRequest.asJson.toString)),
+        new SNSRecord().withSns(new SNSEvent.SNS().withMessage(actualRequest.asJson.toString)),
+        new SNSRecord().withSns(new SNSEvent.SNS().withMessage(actualRequest.asJson.toString)),
+      )
+      val evt = new SNSEvent().withRecords(recods.asJava)
+
+      val mockProcessRecord = mock[Function3[RequestModel,Settings,ContainerTaskManager,Future[Either[String,String]]]]
+      mockProcessRecord.apply(any,any,any) returns Future(Right("mock was called"))
+
+      val mockSendToFloodQueue = mock[Function3[AmazonSQS, RequestModel, String, Try[SendMessageResult]]]
+      mockSendToFloodQueue.apply(any, any, any).returns(Success(new SendMessageResult().withMessageId("fake-id")))
+
+      val toTest = new RequestLambdaMain {
+        override def getEcsClient: AmazonECS = mock[AmazonECS]
+
+        override def getSnsClient: AmazonSNS = mock[AmazonSNS]
+
+        override def getSqsClient: AmazonSQS = mock[AmazonSQS]
+
+        override def getSettings: Settings = Settings("fake-cluster-name","fake-task-def","fake-container-name",None,"fake-reply-topic","fake-role-arn","fake-topic","vpreset","apreset","floodQueue",50)
+
+        override def processRequest(model: RequestModel, settings:Settings, taskMgr: ContainerTaskManager): Future[Either[String, String]] = mockProcessRecord(model, settings, taskMgr)
+
+        override def sendToFloodQueue(sqsClient: AmazonSQS, rq: RequestModel, floodQueue: String): Try[SendMessageResult] = mockSendToFloodQueue(sqsClient, rq, floodQueue)
+        val mockCheckCapacity = mock[Function3[RequestModel, Settings,ContainerTaskManager, Boolean]]
+        mockCheckCapacity.apply(any, any, any).returns(true, true, false)
+        override def checkEcsCapacity(model: RequestModel, settings: Settings, taskMgr: ContainerTaskManager): Boolean = mockCheckCapacity(model, settings, taskMgr)
+      }
+
+      val result = toTest.handleRequest(evt, mock[Context])
+      there were two(mockProcessRecord).apply(any,any,any)
+      there was one(mockSendToFloodQueue)
     }
   }
 }

--- a/SweeperLambda/src/main/scala/SweeperLambdaMain.scala
+++ b/SweeperLambda/src/main/scala/SweeperLambdaMain.scala
@@ -26,7 +26,10 @@ class SweeperLambdaMain extends RequestHandler[java.util.LinkedHashMap[String,Ob
     * @return true if there are potentially more to go, false if we stop now.
     */
   def pullMessages(queueUrl:String, topicArn:String, client:AmazonSQS, snsClient:AmazonSNS) = {
-    val baseRq = new ReceiveMessageRequest().withQueueUrl(queueUrl).withWaitTimeSeconds(2)
+    //use short polling by default, return nothing if we can't find it.
+    //note, that this queries a subset of servers so might not get everything, anyway.
+    //assumption is that there should not be much hanging around on the queue though.
+    val baseRq = new ReceiveMessageRequest().withQueueUrl(queueUrl).withWaitTimeSeconds(0)
     val rq = messageLimit match {
       case None=>baseRq
         //SQS will receive a maximum of 10 messages in a batch

--- a/SweeperLambda/src/main/scala/SweeperLambdaMain.scala
+++ b/SweeperLambda/src/main/scala/SweeperLambdaMain.scala
@@ -1,0 +1,73 @@
+import java.util
+
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.amazonaws.services.sns.{AmazonSNS, AmazonSNSClientBuilder}
+import com.amazonaws.services.sns.model.{MessageAttributeValue, PublishRequest}
+import com.amazonaws.services.sqs.{AmazonSQS, AmazonSQSClientBuilder}
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest
+
+import scala.collection.JavaConverters._
+
+class SweeperLambdaMain extends RequestHandler[java.util.LinkedHashMap[String,Object],Unit]{
+  protected def getSqsQueue = sys.env("FLOOD_QUEUE_URL")
+  protected def getSnsTopic = sys.env("INPUT_TOPIC_ARN")
+  protected def messageLimit = sys.env.get("MESSAGE_LIMIT").map(_.toInt)
+
+  protected def getSqsClient = AmazonSQSClientBuilder.defaultClient()
+  protected def getSnsClient = AmazonSNSClientBuilder.defaultClient()
+
+  /**
+    * pull messages from an SQS queue and republish them.
+    *
+    * @param queueUrl
+    * @param topicArn
+    * @param client
+    * @param snsClient
+    * @return true if there are potentially more to go, false if we stop now.
+    */
+  def pullMessages(queueUrl:String, topicArn:String, client:AmazonSQS, snsClient:AmazonSNS) = {
+    val baseRq = new ReceiveMessageRequest().withQueueUrl(queueUrl).withWaitTimeSeconds(2)
+    val rq = messageLimit match {
+      case None=>baseRq
+        //SQS will receive a maximum of 10 messages in a batch
+      case Some(limit)=>if(limit<10) baseRq.withMaxNumberOfMessages(limit) else baseRq.withMaxNumberOfMessages(10)
+    }
+
+    val result = client.receiveMessage(rq)
+    val msgs = result.getMessages.asScala.toList
+
+    println(s"Received ${msgs.length} messages")
+    if(msgs.isEmpty){
+      0
+    } else {
+      msgs.foreach(msg=>{
+        val attribs = msg.getAttributes.asScala
+        val attempt = attribs.get("archivehunter_attempt").map(_.toInt).getOrElse(0)
+
+        val sendRq = new PublishRequest()
+          .withTopicArn(topicArn)
+          .withMessage(msg.getBody)
+          .withMessageAttributes(Map("archivehunter_attempt"->new MessageAttributeValue().withStringValue(attempt.toString).withDataType("Number")).asJava)
+
+        val result = snsClient.publish(sendRq)
+        println(s"Re-sent message with id ${result.getMessageId}")
+      })
+      msgs.length
+    }
+  }
+
+  override def handleRequest(i: util.LinkedHashMap[String, Object], context: Context): Unit = {
+    println("Sweeper lambda starting up")
+
+    var ctr=0
+    var received = 0
+    do {
+      println("Pulling more messages")
+      received = pullMessages(getSqsQueue, getSnsTopic, getSqsClient, getSnsClient)
+      ctr += received
+      println(s"Processed message count: $ctr")
+    } while (received>0)
+
+    println("Sweeper lambda completed")
+  }
+}

--- a/TranscoderReplyLambda/src/test/scala/ReplyLambdaMainSpec.scala
+++ b/TranscoderReplyLambda/src/test/scala/ReplyLambdaMainSpec.scala
@@ -9,6 +9,7 @@ import io.circe.syntax._
 import io.circe.generic.auto._
 
 import scala.collection.JavaConverters._
+import scala.util.{Success, Try}
 
 class ReplyLambdaMainSpec extends Specification with Mockito with RequestModelEncoder with TranscoderMessageDecoder with JobReportStatusEncoder {
   "ReplyLambdaMain.processMessage" should {
@@ -89,7 +90,7 @@ class ReplyLambdaMainSpec extends Specification with Mockito with RequestModelEn
         override val snsClient: AmazonSNSAsync = mockedSnsClient
         override def getReplyTopic: String = "fake-reply-topic"
 
-        override def getPipelineConfig(pipelineId: String): Option[Pipeline] = Some(new Pipeline().withOutputBucket("proxybucket"))
+        override def getPipelineConfig(pipelineId: String): Try[Option[Pipeline]] = Success(Some(new Pipeline().withOutputBucket("proxybucket")))
       }
 
       val result = main.processMessage(fakeMsg,"reply-topic")

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(RiffRaffArtifact)
 lazy val root = (project in file("."))
   .settings(
     name := "ArchiveHunterProxyLambdas"
-  ).aggregate(requestLambda, ecsAlertLambda, transcoderReplyLambda)
+  ).aggregate(requestLambda, ecsAlertLambda, transcoderReplyLambda, sweeperLambda)
 
 lazy val common = (project in file("common"))
   .settings(
@@ -83,6 +83,32 @@ lazy val `transcoderReplyLambda` = (project in file("TranscoderReplyLambda"))
     }
   )
 
+lazy val `sweeperLambda` = (project in file("SweeperLambda"))
+  .dependsOn(common)
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.amazonaws" % "aws-java-sdk-lambda" % awsSdkVersion,
+      "com.amazonaws" % "aws-lambda-java-events" % "2.1.0",
+      "com.amazonaws" % "aws-lambda-java-core" % "1.0.0",
+      "com.amazonaws" % "aws-java-sdk-sns" % awsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-sqs" % awsSdkVersion,
+      "org.slf4j" % "slf4j-api" % "1.7.25",
+      "com.amazonaws" % "aws-lambda-java-log4j2" % "1.0.0",
+      "org.specs2" %% "specs2-core" % specs2Version % "test",
+      "org.specs2" %% "specs2-mock" % specs2Version % "test"
+    ),
+    assemblyJarName in assembly := "sweeperLambda.jar",
+    assemblyMergeStrategy in assembly := {
+      case PathList("javax", "servlet", xs @ _*)         => MergeStrategy.first
+      case PathList(ps @ _*) if ps.last endsWith ".html" => MergeStrategy.first
+      case "application.conf" => MergeStrategy.concat
+      //META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat
+      case PathList("META-INF","org","apache","logging","log4j","core","config","plugins","Log4j2Plugins.dat") => MergeStrategy.last
+      case x=>
+        val oldStrategy = (assemblyMergeStrategy in assembly).value
+        oldStrategy(x)
+    }
+  )
 lazy val `ecsAlertLambda` = (project in file("ECSAlertLambda"))
   .dependsOn(common)
   .settings(
@@ -122,7 +148,8 @@ riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffManifestProjectName := "multimedia:ArchiveHunterProxyFramework"
 riffRaffArtifactResources := Seq(
   (assembly in requestLambda).value -> s"archivehunter-proxyrequest-lambda/${(assembly  in requestLambda).value.getName}",
-  (assembly  in ecsAlertLambda).value -> s"archivehunter-proxyecsalert-lambda/${(assembly in ecsAlertLambda).value.getName}",
+  (assembly in sweeperLambda).value -> s"archivehunter-sweeper-lambda/${(assembly in sweeperLambda).value.getName}",
+  (assembly in ecsAlertLambda).value -> s"archivehunter-proxyecsalert-lambda/${(assembly in ecsAlertLambda).value.getName}",
   (assembly in transcoderReplyLambda).value -> s"archivehunter-transcoderreply-lambda/${(assembly in transcoderReplyLambda).value.getName}",
   (baseDirectory in Global in root).value / "riff-raff.yaml" -> "riff-raff.yaml",
 )

--- a/cloudformation/archivehunter-proxy-framework.yaml
+++ b/cloudformation/archivehunter-proxy-framework.yaml
@@ -142,6 +142,7 @@ Resources:
               - sqs:SendMessage
             Resource:
               - !GetAtt FloodQueue.Arn
+              - !GetAtt RequestDeadLetter.Arn
       - PolicyName: TranscoderAccess
         PolicyDocument:
           Version: 2012-10-17
@@ -214,7 +215,7 @@ Resources:
       Runtime: java8
       Timeout: 60
       DeadLetterConfig:
-        TargetArn: !GetAtt FloodQueue.Arn
+        TargetArn: !GetAtt RequestDeadLetter.Arn
       Tags:
       - Key: App
         Value: !Ref App
@@ -565,6 +566,17 @@ Resources:
                 - !Ref InputTopic
 
   FloodQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      Tags:
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
+  RequestDeadLetter:
     Type: AWS::SQS::Queue
     Properties:
       Tags:

--- a/cloudformation/archivehunter-proxy-framework.yaml
+++ b/cloudformation/archivehunter-proxy-framework.yaml
@@ -107,6 +107,13 @@ Resources:
             - !GetAtt ProxyingCluster.Arn
             - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task/*
             - !Sub arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:task-definition/*
+      - PolicyName: ContainerCheck
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            - Effect: Allow
+              Action: ecs:DescribeTasks
+              Resource: "*"
       - PolicyName: ContainerRoleAccess
         PolicyDocument:
           Version: 2012-10-17

--- a/cloudformation/archivehunter-proxy-framework.yaml
+++ b/cloudformation/archivehunter-proxy-framework.yaml
@@ -437,6 +437,113 @@ Resources:
       SourceArn: !Ref TranscoderReplyTopic
       FunctionName: !GetAtt TranscoderReplyLambda.Arn
 
+  SweeperLambdaSchedule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Pick up events on the transcoding framework "flood queue"
+      ScheduleExpression: rate(1 minute)
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt SweeperLambda.Arn
+          Id: !Sub ${Stack}-${App}Sweeper-${Stage}
+
+  SweeperInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt SweeperLambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt SweeperLambdaSchedule.Arn
+
+  SweeperLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !FindInMap [RegionalBuckets, !Ref "AWS::Region", Name]
+        S3Key: !Sub ${Stack}/${Stage}/archivehunter-sweeper-lambda/sweeperLambda.jar
+      Environment:
+        Variables:
+          FLOOD_QUEUE_URL: !Ref FloodQueue
+          INPUT_TOPIC_ARN: !Ref InputTopic
+          MESSAGE_LIMIT: 20
+      Handler: SweeperLambdaMain
+      FunctionName: !Sub archivehunter-sweeperlambda-${Stage}
+      MemorySize: 768
+      Role: !GetAtt SweeperLambdaRole.Arn
+      Runtime: java8
+      Timeout: 60
+      Tags:
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+      Description: Pick up anything left on the flood queue and re-process
+
+  SweeperLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: LambdaNecessities
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:CreateNetworkInterface
+                  - ec2:DescribeNetworkInterfaces
+                  - ec2:DeleteNetworkInterface
+                  - ec2:DescribeInstances
+                  - ec2:DescribeInstanceStatus
+                  - ec2:DescribeTags
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "*"
+        - PolicyName: SQSAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action:
+                - sqs:ReceiveMessage
+                - sqs:DeleteMessage
+                - sqs:DeleteMessageBatch
+              Resource:
+                - !GetAtt FloodQueue.Arn
+        - PolicyName: SNSAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              Effect: Allow
+              Action:
+                - sns:Publish
+              Resource:
+                - !Ref InputTopic
+
+  FloodQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      Tags:
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
 Outputs:
   InputTopic:
     Description: SNS topic that triggers actions

--- a/cloudformation/archivehunter-proxy-framework.yaml
+++ b/cloudformation/archivehunter-proxy-framework.yaml
@@ -383,6 +383,7 @@ Resources:
         Variables:
           REPLY_TOPIC_ARN: !Ref ReplyTopic
           ETS_ROLE_ARN: !GetAtt TranscodingRole.Arn
+          FLOOD_QUEUE: !Ref TranscoderReplyFloodQueue
       Handler: ReplyLambdaMain
       FunctionName: !Sub archivehunter-transcoderreply-${Stage}
       MemorySize: 768
@@ -429,6 +430,15 @@ Resources:
             - logs:CreateLogStream
             - logs:PutLogEvents
             Resource: "*"
+      - PolicyName: FloodQueue
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              - !GetAtt TranscoderReplyFloodQueue.Arn
       - PolicyName: SNSAccess
         PolicyDocument:
           Version: 2012-10-17
@@ -483,6 +493,7 @@ Resources:
       Environment:
         Variables:
           FLOOD_QUEUE_URL: !Ref FloodQueue
+          TRANSCODER_FLOOD_QUEUE: !Ref TranscoderReplyFloodQueue
           INPUT_TOPIC_ARN: !Ref InputTopic
           MESSAGE_LIMIT: 20
       Handler: SweeperLambdaMain
@@ -542,6 +553,7 @@ Resources:
                 - sqs:DeleteMessageBatch
               Resource:
                 - !GetAtt FloodQueue.Arn
+                - !GetAtt TranscoderReplyFloodQueue.Arn
         - PolicyName: SNSAccess
           PolicyDocument:
             Version: 2012-10-17
@@ -553,6 +565,17 @@ Resources:
                 - !Ref InputTopic
 
   FloodQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      Tags:
+        - Key: App
+          Value: !Ref App
+        - Key: Stack
+          Value: !Ref Stack
+        - Key: Stage
+          Value: !Ref Stage
+
+  TranscoderReplyFloodQueue:
     Type: AWS::SQS::Queue
     Properties:
       Tags:

--- a/cloudformation/archivehunter-proxy-framework.yaml
+++ b/cloudformation/archivehunter-proxy-framework.yaml
@@ -126,6 +126,15 @@ Resources:
             - sns:Publish
             Resource:
             - !Ref ReplyTopic
+      - PolicyName: FloodQueue
+        PolicyDocument:
+          Version: 2012-10-17
+          Statement:
+            Effect: Allow
+            Action:
+              - sqs:SendMessage
+            Resource:
+              - !GetAtt FloodQueue.Arn
       - PolicyName: TranscoderAccess
         PolicyDocument:
           Version: 2012-10-17
@@ -190,12 +199,15 @@ Resources:
           ETS_MESSAGE_TOPIC: !Ref TranscoderReplyTopic
           VIDEO_PRESET_ID: !Ref VideoTranscodingPresetId
           AUDIO_PRESET_ID: !Ref AudioTranscodingPresetId
+          FLOOD_QUEUE: !Ref FloodQueue
       Handler: RequestLambdaMain
       FunctionName: !Sub archivehunter-requestlambda-${Stage}
       MemorySize: 768
       Role: !GetAtt RequestLambdaRole.Arn
       Runtime: java8
       Timeout: 60
+      DeadLetterConfig:
+        TargetArn: !GetAtt FloodQueue.Arn
       Tags:
       - Key: App
         Value: !Ref App
@@ -468,10 +480,10 @@ Resources:
           MESSAGE_LIMIT: 20
       Handler: SweeperLambdaMain
       FunctionName: !Sub archivehunter-sweeperlambda-${Stage}
-      MemorySize: 768
+      MemorySize: 512
       Role: !GetAtt SweeperLambdaRole.Arn
       Runtime: java8
-      Timeout: 60
+      Timeout: 20
       Tags:
         - Key: App
           Value: !Ref App


### PR DESCRIPTION
Implemented a "flood queue", which is used both as a DLQ for the query lambda and also if it catches any timeout exceptions from external services.

This is then monitored by a sweeper lambda, which polls the contents of the queue every minute and reschedules any jobs it finds by pushing them back onto the input topic.

Also implemented is a limit to the number of concurrent ECS tasks; before any new task is scheduled, the total number is checked and if too high then the job is pushed onto the flood queue