### PR TITLE
Fix for ensuring that files with '+' in the name can be transcoded

### DIFF
--- a/.idea/modules/Common.iml
+++ b/.idea/modules/Common.iml
@@ -1,31 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="common [file:/Users/localhome/workdev/ArchiveHunterProxyImage/]" external.linked.project.path="$MODULE_DIR$/../../common" external.root.project.path="$MODULE_DIR$/../.." external.system.id="SBT" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="common [file:/home/andy/workdev/ArchiveHunterProxyFramework/]" external.linked.project.path="$MODULE_DIR$/../../common" external.root.project.path="$MODULE_DIR$/../.." external.system.id="SBT" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/../../common/target/scala-2.12/classes" />
     <output-test url="file://$MODULE_DIR$/../../common/target/scala-2.12/test-classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../common">
       <sourceFolder url="file://$MODULE_DIR$/../../common/src/main/scala" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../common/target/scala-2.12/src_managed/main" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../../common/target/scala-2.12/src_managed/test" isTestSource="true" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/../../common/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
-    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
     <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-core_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-generic_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-java8_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-jawn_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.spire-math:jawn-parser_2.12:0.11.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-core_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-kernel_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:cats-macros_2.12:1.0.1:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
   </component>
 </module>

--- a/.idea/modules/ecsAlertLambda.iml
+++ b/.idea/modules/ecsAlertLambda.iml
@@ -1,24 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="ecsAlertLambda [file:/Users/localhome/workdev/ArchiveHunterProxyImage/]" external.linked.project.path="$MODULE_DIR$/../../ECSAlertLambda" external.root.project.path="$MODULE_DIR$/../.." external.system.id="SBT" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="ecsAlertLambda [file:/home/andy/workdev/ArchiveHunterProxyFramework/]" external.linked.project.path="$MODULE_DIR$/../../ECSAlertLambda" external.root.project.path="$MODULE_DIR$/../.." external.system.id="SBT" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/../../ECSAlertLambda/target/scala-2.12/classes" />
     <output-test url="file://$MODULE_DIR$/../../ECSAlertLambda/target/scala-2.12/test-classes" />
     <exclude-output />
     <content url="file://$MODULE_DIR$/../../ECSAlertLambda">
-      <sourceFolder url="file://$MODULE_DIR$/../../ECSAlertLambda/src/main/scala" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/../../ECSAlertLambda/target/scala-2.12/src_managed/main" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../../ECSAlertLambda/target/scala-2.12/src_managed/test" isTestSource="true" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/../../ECSAlertLambda/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="Common" exported="" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-core:2.8.2:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-ecs:1.11.346:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-lambda:1.11.346:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sqs:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-core:1.1.0:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-events:2.1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-log4j2:1.0.0:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:jmespath-java:1.11.346:jar" level="project" />
     <orderEntry type="library" name="sbt: com.chuusai:shapeless_2.12:2.3.3:jar" level="project" />
     <orderEntry type="library" name="sbt: com.fasterxml.jackson.core:jackson-annotations:2.6.0:jar" level="project" />
@@ -34,16 +32,21 @@
     <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
     <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
     <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
     <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
     <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-api:2.8.2:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-core:2.8.2:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-core_2.12:4.3.2:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-fp_2.12:4.3.2:jar" level="project" />
@@ -56,11 +59,5 @@
     <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
     <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
     <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-core:1.1.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-log4j2:1.0.0:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-api:2.8.2:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
-    <orderEntry type="module" module-name="Common" exported="" />
   </component>
 </module>

--- a/.idea/modules/transcoderReplyLambda.iml
+++ b/.idea/modules/transcoderReplyLambda.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id="transcoderReplyLambda [file:/Users/localhome/workdev/ArchiveHunterProxyImage/]" external.linked.project.path="$MODULE_DIR$/../../TranscoderReplyLambda" external.root.project.path="$MODULE_DIR$/../.." external.system.id="SBT" type="JAVA_MODULE" version="4">
+<module external.linked.project.id="transcoderReplyLambda [file:/home/andy/workdev/ArchiveHunterProxyFramework/]" external.linked.project.path="$MODULE_DIR$/../../TranscoderReplyLambda" external.root.project.path="$MODULE_DIR$/../.." external.system.id="SBT" type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/../../TranscoderReplyLambda/target/scala-2.12/classes" />
     <output-test url="file://$MODULE_DIR$/../../TranscoderReplyLambda/target/scala-2.12/test-classes" />
@@ -7,17 +7,16 @@
     <content url="file://$MODULE_DIR$/../../TranscoderReplyLambda">
       <sourceFolder url="file://$MODULE_DIR$/../../TranscoderReplyLambda/src/main/scala" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/../../TranscoderReplyLambda/src/test/scala" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../../TranscoderReplyLambda/target/scala-2.12/src_managed/main" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/../../TranscoderReplyLambda/target/scala-2.12/src_managed/test" isTestSource="true" generated="true" />
       <excludeFolder url="file://$MODULE_DIR$/../../TranscoderReplyLambda/target" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="module" module-name="Common" exported="" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-core:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sqs:1.11.346:jar" level="project" />
-    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sns:1.11.346:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-elastictranscoder:1.11.346:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-lambda:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sns:1.11.346:jar" level="project" />
+    <orderEntry type="library" name="sbt: com.amazonaws:aws-java-sdk-sqs:1.11.346:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-core:1.1.0:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-events:2.1.0:jar" level="project" />
     <orderEntry type="library" name="sbt: com.amazonaws:aws-lambda-java-log4j2:1.0.0:jar" level="project" />
@@ -36,8 +35,8 @@
     <orderEntry type="library" name="sbt: io.circe:circe-numbers_2.12:0.9.3:jar" level="project" />
     <orderEntry type="library" name="sbt: io.circe:circe-parser_2.12:0.9.3:jar" level="project" />
     <orderEntry type="library" name="sbt: joda-time:joda-time:2.8.1:jar" level="project" />
-    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy-agent:1.8.3:jar" level="project" />
+    <orderEntry type="library" scope="TEST" name="sbt: net.bytebuddy:byte-buddy:1.8.3:jar" level="project" />
     <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpclient:4.5.5:jar" level="project" />
     <orderEntry type="library" name="sbt: org.apache.httpcomponents:httpcore:4.4.9:jar" level="project" />
     <orderEntry type="library" name="sbt: org.apache.logging.log4j:log4j-api:2.8.2:jar" level="project" />
@@ -45,10 +44,10 @@
     <orderEntry type="library" scope="TEST" name="sbt: org.hamcrest:hamcrest-core:1.3:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.mockito:mockito-core:2.18.0:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.objenesis:objenesis:2.6:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
-    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-parser-combinators_2.12:1.1.1:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.scala-lang.modules:scala-xml_2.12:1.1.0:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-library:2.12.4:jar" level="project" />
+    <orderEntry type="library" name="sbt: org.scala-lang:scala-reflect:2.12.4:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.scala-sbt:test-interface:1.0:jar" level="project" />
     <orderEntry type="library" name="sbt: org.slf4j:slf4j-api:1.7.25:jar" level="project" />
     <orderEntry type="library" scope="TEST" name="sbt: org.specs2:specs2-common_2.12:4.3.2:jar" level="project" />
@@ -63,6 +62,5 @@
     <orderEntry type="library" name="sbt: org.typelevel:machinist_2.12:0.6.2:jar" level="project" />
     <orderEntry type="library" name="sbt: org.typelevel:macro-compat_2.12:1.1.1:jar" level="project" />
     <orderEntry type="library" name="sbt: software.amazon.ion:ion-java:1.0.2:jar" level="project" />
-    <orderEntry type="module" module-name="Common" exported="" />
   </component>
 </module>

--- a/ProxyRequestLambda/src/main/scala/PathFunctions.scala
+++ b/ProxyRequestLambda/src/main/scala/PathFunctions.scala
@@ -28,8 +28,14 @@ object PathFunctions {
     * @return
     */
   def breakdownS3Uri(s3Uri:String) = {
-    val u = new URI(s3Uri)
-    if(u.getHost==null){  //if there is no s3:// prefix, then we only get path back. So assume that';s the bucket.
+    /*
+    if there is a + in the filename, it's decoded to a ' ' and this means that the file can't be found and won't be transcoded.
+    So, we encode the + here to make sure that it comes through to the transcoder.
+    This is tested in PathFunctionsSpec
+     */
+    val withReplacement = s3Uri.replaceAll("\\+","%252B")
+    val u = new URI(withReplacement)
+    if(u.getHost==null){  //if there is no s3:// prefix, then we only get path back. So assume that's the bucket.
       (u.getPath, "")
     } else {
       (u.getHost, stripped(URLDecoder.decode(u.getPath,"UTF-8")))

--- a/ProxyRequestLambda/src/test/scala/PathFunctionsSpec.scala
+++ b/ProxyRequestLambda/src/test/scala/PathFunctionsSpec.scala
@@ -24,9 +24,9 @@ class PathFunctionsSpec extends Specification {
       result mustEqual("bucket","")
     }
 
-    "remove url-encoding from returned portions" in {
-      val result = PathFunctions.breakdownS3Uri("s3://bucket/path/to/my+file+with+spaces.ext")
-      result mustEqual ("bucket","path/to/my file with spaces.ext")
+    "not remove + from string" in {
+      val result = PathFunctions.breakdownS3Uri("s3://bucket/path/to/you+me.ext")
+      result mustEqual ("bucket","path/to/you+me.ext")
     }
 
     "remove url-encoding from returned portions again" in {


### PR DESCRIPTION
## What does this change?
Re-encodes '+' symbols in the URL to %2B when decoding S3 URIs.
The percent-encoding is already decoded correctly, this will ensure that files with a '+' in the filename do not have the '+' converted to ' ' and therefore not transcode https://codemill.atlassian.net/browse/GP-415

## How to test
Tested in CI, see updated tests for details.
You can turn on proxing for a DEV environment bucket and then add a file with a '+' in the filename. It should go through ETS correctly.

## How can we measure success?
Less ETS errors and more proxies in ArchiveHunter
